### PR TITLE
bugfix/APPS-2909 — fix for menu content being inaccessible

### DIFF
--- a/src/components/navigation/NavItems.js
+++ b/src/components/navigation/NavItems.js
@@ -60,6 +60,7 @@ const NavItemsWrapper = styled.div`
 const PortalOuterWrapper = styled.div`
   position: fixed;
   height: 100%;
+  overflow: scroll;
   right: 0;
   top: 0;
   width: 100%;


### PR DESCRIPTION
fixing issue where, if screen height is less than menu height, the menu content is hidden away and inaccessible. now menu itself scrolls:
![26f49bd2bf9be2347233e542336c4bc3](https://user-images.githubusercontent.com/32921059/117698131-38ad3780-b178-11eb-980c-a3e22ed191c8.gif)
